### PR TITLE
Fix typo in dependency declaration and add issueTrackerURL

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,6 +1,7 @@
 modLoader="javafml"
 loaderVersion="[32,)"
 license="MIT License"
+issueTrackerURL="https://github.com/mactso/HarderSpawners/issues"
 [[mods]]
 modId="harderspawners"
 version="${file.jarVersion}"
@@ -17,7 +18,7 @@ description='Harder Spawners Mod.'
     ordering="NONE"
     side="SERVER"
 
-[[dependencies.harderspawnwers]]
+[[dependencies.harderspawners]]
     modId="minecraft"
     mandatory=true
     versionRange="[1.16.1,1.17.0)"


### PR DESCRIPTION
There was a typo in one of the dependency declarations, pointing at an incorrect modId.

I've also added the issueTrackerURL as this helps people (like me) finding this repository.

Cheers,
Griefed